### PR TITLE
修正 超夢 命名

### DIFF
--- a/src/data/gamemaster.json
+++ b/src/data/gamemaster.json
@@ -4546,7 +4546,7 @@
         }
     }, {
         "dex": 150,
-        "speciesName": "超夢-裝甲型態",
+        "speciesName": "超夢 裝甲型態",
         "speciesId": "mewtwo_armored",
         "baseStats": {
             "atk": 182,


### PR DESCRIPTION
其它不同型態都是用空白分隔
去掉 `-` 使其一致